### PR TITLE
Preserve source locations in reader and module-begin

### DIFF
--- a/lang/reader.rkt
+++ b/lang/reader.rkt
@@ -7,5 +7,5 @@
 
 (define (read-syntax-p5 src in)
   (define module-datum `(module p5-syntax p5/p5
-                          ,(port->list read in)))
+                          ,(port->list (λ (in) (read-syntax src in)) in)))
   (datum->syntax #f module-datum))

--- a/p5.rkt
+++ b/p5.rkt
@@ -1,6 +1,7 @@
 #lang racket
 (require urlang urlang/for urlang/extra)
 (require "p5-ids.rkt")
+(require (for-syntax syntax/strip-context))
 
 (provide (rename-out [module-begin-p5 #%module-begin]))
 
@@ -8,7 +9,7 @@
 (define-syntax (module-begin-p5 stx)
   (syntax-case stx ()
     [(_module-begin-p5 . body)
-     (with-syntax ([body (datum->syntax #'here (syntax->datum #'body))])
+     (with-syntax ([body (replace-context #'here #'body)])
        (syntax/loc stx
          (#%plain-module-begin
           (displayln (p5 . body)))))]))


### PR DESCRIPTION
This small patch preserves the source locations of all identifiers in both the reader and in module-begin.

The neat effect is that errors like "unbound identifier" will show the line and column number
of the identifier that were misspelled.

In the racket-mode repl one can click on the source location in the repl, and then the cursor will move
to the place of the error. I think DrRacket simply jumps to the error location directly.
